### PR TITLE
Add formatting for use as environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ SECRET_ACCESS_KEY '<secret-access-key>'
 SESSION_TOKEN '<temporary-token>'
 ```
 
+### Environment Variables
+
+To use your AWS credentials as [environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html):
+
+```bash
+$ aws-key-formatter env
+AWS_ACCESS_KEY_ID=<access-key-id>
+AWS_SECRET_ACCESS_KEY=<secret-access-key>
+
+# If you want the session token included as well
+$ aws-key-formatter env --token
+ACCESS_KEY_ID=<access-key-id>
+SECRET_ACCESS_KEY=<secret-access-key>
+SESSION_TOKEN=<temporary-token>
+```
+
 ## Contributing
 
 <!-- TODO: add some contributing guidelines -->

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ To use your AWS credentials as the `Authorization` parameter in a Redshift
 command (See [the Redshift docs](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html#copy-access-key-id)):
 
 ```bash
-$ aws-key-formatter
+$ aws-key-formatter redshift
 ACCESS_KEY_ID '<access-key-id>'
 SECRET_ACCESS_KEY '<secret-access-key>'
 
 # If you want the session token included as well
-$ aws-key-formatter --token
+$ aws-key-formatter redshift --token
 ACCESS_KEY_ID '<access-key-id>'
 SECRET_ACCESS_KEY '<secret-access-key>'
 SESSION_TOKEN '<temporary-token>'

--- a/src/aws_key_formatter/__main__.py
+++ b/src/aws_key_formatter/__main__.py
@@ -1,0 +1,4 @@
+from . import cli
+
+
+cli.main()

--- a/src/aws_key_formatter/aws_key_formatter.py
+++ b/src/aws_key_formatter/aws_key_formatter.py
@@ -49,9 +49,7 @@ def main(formatter_type: str, aws_profile: str, include_token: bool):
     }
 
     formatter = formatters.get(formatter_type)
-    formatted_str = formatter(creds, include_token)
-
-    print(formatted_str)
+    return formatter(creds, include_token)
 
 
 if __name__ == '__main__':

--- a/src/aws_key_formatter/aws_key_formatter.py
+++ b/src/aws_key_formatter/aws_key_formatter.py
@@ -20,6 +20,18 @@ def _format_redshift_credentials(creds, include_token: bool) -> str:
     return formatted_str
 
 
+def _format_env_credentials(creds, include_token: bool) -> str:
+    formatted_str = textwrap.dedent(
+        f"""\
+        ACCESS_KEY_ID={creds.access_key}
+        SECRET_ACCESS_KEY={creds.secret_key}
+        {f"SESSION_TOKEN={creds.token}" if include_token else ""}
+        """
+    ).strip()
+
+    return formatted_str
+
+
 def _get_credentials_for_profile(aws_profile: str):
     session = boto3.Session(profile_name=aws_profile)
     return _get_creds_from_session(session)

--- a/src/aws_key_formatter/cli.py
+++ b/src/aws_key_formatter/cli.py
@@ -10,13 +10,14 @@ from .__version__ import __version__
 
 @click.command()
 @click.version_option(version=__version__, prog_name='aws-key-formatter')
+@click.argument('formatter', type=click.Choice(['redshift', 'env']))
 @click.option('-p', '--profile', default='default', show_default=True, help='AWS CLI Profile name')
 @click.option('--token/--no-token', ' -t/', default=False, show_default=True, help='Include AWS Session Token?')
-def main(profile: str, token: bool):
+def main(formatter: str, profile: str, token: bool):
     """Console script for aws_key_formatter."""
     # TODO: Have the aws_key_formatter function return the string,
     # then have this function do the `click.echo` to output it.
-    aws_key_formatter.main(profile, token)
+    aws_key_formatter.main(formatter, profile, token)
 
     return 0
 

--- a/src/aws_key_formatter/cli.py
+++ b/src/aws_key_formatter/cli.py
@@ -15,8 +15,6 @@ from .__version__ import __version__
 @click.option('--token/--no-token', ' -t/', default=False, show_default=True, help='Include AWS Session Token?')
 def main(formatter: str, profile: str, token: bool):
     """Console script for aws_key_formatter."""
-    # TODO: Have the aws_key_formatter function return the string,
-    # then have this function do the `click.echo` to output it.
     formatted_str = aws_key_formatter.main(formatter, profile, token)
     click.echo(formatted_str)
 

--- a/src/aws_key_formatter/cli.py
+++ b/src/aws_key_formatter/cli.py
@@ -17,7 +17,8 @@ def main(formatter: str, profile: str, token: bool):
     """Console script for aws_key_formatter."""
     # TODO: Have the aws_key_formatter function return the string,
     # then have this function do the `click.echo` to output it.
-    aws_key_formatter.main(formatter, profile, token)
+    formatted_str = aws_key_formatter.main(formatter, profile, token)
+    click.echo(formatted_str)
 
     return 0
 


### PR DESCRIPTION
Refactored so that each type of formatting is now part of
the command. Thus, the original redshift formatting can be invoked
with `aws-key-formatter redshift`.

Added a new `env` command to use your credentials as environment variables.
Will output in the following format:

```bash
$ aws-key-formatter env --token
ACCESS_KEY_ID=<access-key-id>
SECRET_ACCESS_KEY=<secret-access-key>
SESSION_TOKEN=<temporary-token>
```